### PR TITLE
[bugFix] Read Command 인자 개수 오류 수정

### DIFF
--- a/ssd_app/CMD.cpp
+++ b/ssd_app/CMD.cpp
@@ -43,10 +43,20 @@ unsigned int Command::hexStringToInt(const string& hexStr) {
 
 bool Command::isInvalidCommand()
 {
-	if (args.size() != 3) return true;
-	if (!(args[0] == "R" || args[0] == "W")) return true;
-	if (!isNumber(args[1])) return true;
-	if (stoi(args[1]) < 0 || stoi(args[1]) > 99) return true;
-	if (!isValidHex(args[2])) return true;
+	if (args.size() == 2 && args[0] == "R")
+	{
+		if (!isNumber(args[1])) return true;
+		if (stoi(args[1]) < 0 || stoi(args[1]) > 99) return true;
+	}
+	else if (args.size() == 3 && args[0] == "W")
+	{
+		if (!isNumber(args[1])) return true;
+		if (stoi(args[1]) < 0 || stoi(args[1]) > 99) return true;
+		if (!isValidHex(args[2])) return true;
+	}
+	else
+	{
+		return true;
+	}
 	return false;
 }

--- a/ssd_app/CMD.h
+++ b/ssd_app/CMD.h
@@ -24,7 +24,7 @@ public:
 		{
 			cmd = args[0];
 			address = (unsigned int)stoi(args[1]);
-			value = hexStringToInt(args[2]);
+			if(cmd == "W") value = hexStringToInt(args[2]);
 		}
 	}
 
@@ -36,7 +36,7 @@ public:
 		{
 			cmd = args[0][0];
 			address = (unsigned int)stoi(args[1]);
-			value = hexStringToInt(args[2]);
+			if (cmd == "W") value = hexStringToInt(args[2]);
 		}
 	}
 

--- a/ssd_app_gtest/test.cpp
+++ b/ssd_app_gtest/test.cpp
@@ -10,21 +10,31 @@ protected:
 	vector<string> args;
 };
 
-TEST_F(CMDTestFixture, ValidObjectVectorConstructorTest) 
+TEST_F(CMDTestFixture, ValidObjectVectorConstructorTestRead) 
 {
 	args.push_back("R");
+	args.push_back("10");
+
+	Command cmd(args);
+	
+	EXPECT_EQ(cmd.getValid(), true);
+}
+
+TEST_F(CMDTestFixture, ValidObjectVectorConstructorTestWrite)
+{
+	args.push_back("W");
 	args.push_back("10");
 	args.push_back("0xAAAAAAAA");
 
 	Command cmd(args);
-	Command result("R 10 0xAAAAAAAA");
-	
+	Command result("W 10 0xAAAAAAAA");
+
 	EXPECT_EQ(cmd, result);
 }
 
 TEST_F(CMDTestFixture, ValidFlagTest) 
 {
-	args.push_back("R");
+	args.push_back("W");
 	args.push_back("10");
 	args.push_back("0xAAAAAAAA");
 
@@ -46,7 +56,7 @@ TEST_F(CMDTestFixture, InvalidCommandTypeTest)
 
 TEST_F(CMDTestFixture, AddressOutOfRangeTest) 
 {
-	args.push_back("R");
+	args.push_back("W");
 	args.push_back("100");
 	args.push_back("0xAAAAAAAA");
 
@@ -57,7 +67,7 @@ TEST_F(CMDTestFixture, AddressOutOfRangeTest)
 
 TEST_F(CMDTestFixture, AddressTypeErrorTest) 
 {
-	args.push_back("R");
+	args.push_back("W");
 	args.push_back("1a");
 	args.push_back("0xAAAAAAAA");
 
@@ -68,7 +78,7 @@ TEST_F(CMDTestFixture, AddressTypeErrorTest)
 
 TEST_F(CMDTestFixture, DataLengthErrorTest) 
 {
-	args.push_back("R");
+	args.push_back("W");
 	args.push_back("10");
 	args.push_back("0xAAAAAAA");
 
@@ -78,7 +88,7 @@ TEST_F(CMDTestFixture, DataLengthErrorTest)
 }
 
 TEST_F(CMDTestFixture, DataTypeErrorTest) {
-	args.push_back("R");
+	args.push_back("W");
 	args.push_back("10");
 	args.push_back("0xAAAAAAAH");
 


### PR DESCRIPTION
Read Command에서 3개의 인자를 받고 있어 수정합니다.
관련 테스트 케이스도 추가하였습니다.