### PR TITLE
[BugFix] fix return type of testapp1

### DIFF
--- a/ssd_app_test/TestShell.cpp
+++ b/ssd_app_test/TestShell.cpp
@@ -54,7 +54,7 @@ TestShell::EraseRange(const uint32_t startaddr, const uint32_t endaddr)
         ssd_app->Erase(addr, 1);
 }
 
-void
+bool
 TestShell::TestApp1()
 {
     bool is_test_pass = false;


### PR DESCRIPTION
conflict 수정 과정에서 return type을 잘못 수정하는 실수가 있었습니다.
해당 내용 바로 잡았습니다.