### PR TITLE
[bugFix] buffer file을 reopen할 때 사이즈를 초기화 합니다.

### DIFF
--- a/ssd_app/CmdBuffer.cpp
+++ b/ssd_app/CmdBuffer.cpp
@@ -3,6 +3,14 @@
 #include "Eraser.h"
 #include "Writer.h"
 
+CmdBuffer::CmdBuffer(FileManager* buffer) :
+	buffer_(buffer) 
+{
+	std::vector<std::string> lines;
+	buffer_->ReadBufferFile(lines);
+	length_ = lines.size();
+}
+
 bool CmdBuffer::isFull()
 {
 	return length_ == MAX_BUFFER_SIZE;

--- a/ssd_app/CmdBuffer.h
+++ b/ssd_app/CmdBuffer.h
@@ -11,8 +11,7 @@
 class CmdBuffer
 {
 public:
-	CmdBuffer(FileManager* buffer) :
-		buffer_(buffer) {}
+	CmdBuffer(FileManager* buffer);
 
 	bool isFull();
 	uint32_t GetSize();

--- a/ssd_app_gtest/test.cpp
+++ b/ssd_app_gtest/test.cpp
@@ -585,7 +585,6 @@ TEST_F(SSDTest, EraseAfterWrite)
 TEST_F(SSDTest, AddAndGetCommandListICmd)
 {
 	CmdBuffer* cmd_buffer = ssd->GetCmdBuffer();
-	cmd_buffer->Clear();
 
 	std::vector<std::string> args;
 
@@ -612,7 +611,6 @@ TEST_F(SSDTest, AddAndGetCommandListICmd)
 TEST_F(SSDTest, ComapareGetCmdWithBufferFile)
 {
 	CmdBuffer* cmd_buffer = ssd->GetCmdBuffer();
-	cmd_buffer->Clear();
 
 	std::vector<std::string> args;
 
@@ -673,4 +671,37 @@ TEST_F(SSDTest, ReturnBufferSize)
 	}
 
 	EXPECT_EQ(cmd_buffer->GetSize(), 5);
+}
+
+TEST_F(SSDTest, CheckBufferSizeWhenOpen)
+{
+	CmdBuffer* cmd_buffer = ssd->GetCmdBuffer();
+	cmd_buffer->Clear();
+
+	std::vector<std::string> args;
+	args.push_back(std::to_string(ADDRESS));
+	args.push_back("0xFFFFFFFF");
+
+	for (int i = 0; i < 5; i++)
+	{
+		ssd->Run("W", args);
+	}
+
+	EXPECT_EQ(cmd_buffer->GetSize(), 5);
+}
+
+TEST_F(SSDTest, CheckBufferSizeWhenReopen)
+{
+	CmdBuffer* cmd_buffer = ssd->GetCmdBuffer();
+
+	std::vector<std::string> args;
+	args.push_back(std::to_string(ADDRESS));
+	args.push_back("0x12345678");
+
+	for (int i = 0; i < 6; i++)
+	{
+		ssd->Run("W", args);
+	}
+
+	EXPECT_EQ(cmd_buffer->GetSize(), 1);
 }

--- a/ssd_app_gtest/test.cpp
+++ b/ssd_app_gtest/test.cpp
@@ -688,15 +688,10 @@ TEST_F(SSDTest, CheckBufferSizeWhenOpen)
 	}
 
 	EXPECT_EQ(cmd_buffer->GetSize(), 5);
-}
 
-TEST_F(SSDTest, CheckBufferSizeWhenReopen)
-{
-	CmdBuffer* cmd_buffer = ssd->GetCmdBuffer();
-
-	std::vector<std::string> args;
-	args.push_back(std::to_string(ADDRESS));
-	args.push_back("0x12345678");
+	delete(ssd);
+	ssd = new SSD(test_nand, test_result, test_buffer);
+	cmd_buffer = ssd->GetCmdBuffer();
 
 	for (int i = 0; i < 6; i++)
 	{


### PR DESCRIPTION
cmdBuffer 생성시 크기가 0으로 초기화되어 오류발생.
생성시 버퍼에 있는 커맨드의 수를 읽어 크기를 초기화 하도록 변경