### PR TITLE
[Refactoring] Refactoring TestShell UnitTests

### DIFF
--- a/ssd_app_test/Logger.cpp
+++ b/ssd_app_test/Logger.cpp
@@ -48,7 +48,7 @@ Logger::PrintTime(ostringstream& out_ss)
     std::time_t now_time = std::chrono::system_clock::to_time_t(now);
     std::tm* local_time = std::localtime(&now_time);
 
-    log_fout << '['
+    out_ss << '['
         << (local_time->tm_year - 100) << '.'
         << (local_time->tm_mon + 1) << '.'
         << local_time->tm_mday << ' '

--- a/ssd_app_test/TestShell.h
+++ b/ssd_app_test/TestShell.h
@@ -26,7 +26,6 @@ public:
     void Run();
     void ScriptRun(const char* script_path);
     void set_ssd_app(ISSDApp* app);
-    ISSDApp* get_ssd_app(void) { return ssd_app; } //to be deleted
     std::vector<uint32_t> addr_arr;//to be deleted
     std::vector<uint32_t> data_arr;//to be deleted
 private:

--- a/ssd_app_test_gtest/test.cpp
+++ b/ssd_app_test_gtest/test.cpp
@@ -11,8 +11,6 @@
 #include <iostream>
 #include <fstream>
 #include <string>
-#include <chrono>
-#include <ctime>
 using namespace testing;
 using namespace std;
 
@@ -25,268 +23,159 @@ public:
 	MOCK_METHOD(void, Flush, (), (override));
 };
 
-TEST(TestCaseName, TestName) 
-{
-	MockSSDApp app;
-	TestShell test_shell;
-
-	test_shell.set_ssd_app(&app);
-
-	EXPECT_EQ(test_shell.get_ssd_app(), &app);
-}
-
 class TestShellTestFixture : public testing::Test
 {
 public:
 	void SetUp(void)
 	{
-		//open new test script file
-		out_file.open(user_input_script, ofstream::trunc | ofstream::out);
-		cout.rdbuf(out_file.rdbuf());
-		//reopen 
+		cout_buff = cout.rdbuf();
+
+		user_input_out_file.open(user_input_script, ofstream::trunc | ofstream::out);
+		test_console_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
+		cout.rdbuf(test_console_out_file.rdbuf());
+		result_input_file.open(test_result_path, ifstream::in);
+
 		in_file = freopen(user_input_script.c_str(), "rt", stdin);
 
 		Logger::GetLogger().SetPrintLevel(INFO);
 	}
 	void TearDown(void)
 	{
-		out_file.close();
 		fclose(in_file);
-	}
-	string GetTime(void)
-	{
-		auto now = std::chrono::system_clock::now();
-		std::time_t now_time = std::chrono::system_clock::to_time_t(now);
-		std::tm* local_time = std::localtime(&now_time);
 
-		string time = "[" + to_string(local_time->tm_year - 100) + "."
-			+ to_string(local_time->tm_mon + 1) + "."
-			+ to_string(local_time->tm_mday) + " "
-			+ to_string(local_time->tm_hour) + ":"
-			+ to_string(local_time->tm_min) + "] ";
-		return time;
+		result_input_file.close();
+		test_console_out_file.close();
+		user_input_out_file.close();
+
+		cout.rdbuf(cout_buff);
 	}
-	string user_input_script = "./test_script.txt";
+	ofstream user_input_out_file;
+	ofstream test_console_out_file;
+	ifstream result_input_file;
 private:
-	ofstream out_file;
+	string test_result_path = "./test_result.txt";
+	string user_input_script = "./test_script.txt";
+	streambuf* cout_buff;
 	FILE* in_file;
 };
 
-TEST_F(TestShellTestFixture, RunnerTest)
-{
-	string sample_script_path = "SampleScript.lst";
-	ofstream script_fout(sample_script_path, ios_base::out | ios_base::trunc);
-
-	string write_cmd = "Write 1 0x1234AAAA\n";
-	string read_cmd = "Read 1\n";
-	string full_write_cmd = "FullWrite 0x43215678\n";
-	string full_read_cmd = "FullRead\n";
-	string exit_cmd = "Exit\n";
-
-	script_fout<<write_cmd;
-	script_fout<<read_cmd;
-	script_fout<<full_write_cmd;
-	script_fout<<full_read_cmd;
-	script_fout<<exit_cmd;
-	script_fout.close();
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
-
-	SSD_Adaptor app;
-	TestShell test_shell;
-	test_shell.set_ssd_app(&app);
-	test_shell.ScriptRun(sample_script_path.c_str());
-
-	ifstream result_input_file(test_result_path);
-	string result;
-	std::getline(result_input_file, result);
-	EXPECT_EQ(result, "Write 1 0x1234AAAA  ---  Run...Pass");
-	std::getline(result_input_file, result);
-	EXPECT_EQ(result, "Read 1  ---  Run...Pass");
-	std::getline(result_input_file, result);
-	EXPECT_EQ(result, "FullWrite 0x43215678  ---  Run...Pass");
-	std::getline(result_input_file, result);
-	EXPECT_EQ(result, "FullRead  ---  Run...Pass");
-}
-
 TEST_F(TestShellTestFixture, OutputToFile)
 {
-	string user_input;
 	string write_input = "Write 1 0x12345678";
 	string read_input = "Read 1";
 
-	cout << write_input << endl;
-	cout << read_input << endl;
+	user_input_out_file << write_input << endl;
+	user_input_out_file << read_input << endl;
 
-	std::getline(cin, user_input);
+	string user_input;
+	getline(cin, user_input);
 	EXPECT_EQ(user_input, write_input);
-	std::getline(cin, user_input);
+	getline(cin, user_input);
 	EXPECT_EQ(user_input, read_input);
 }
 
 TEST_F(TestShellTestFixture, WriteTest)
 {
-	string user_input = "Write 1 0x12345678";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "Write 1 0x12345678" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Write(_, _)).Times(1);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, FullWriteTest)
 {
-	string user_input = "FullWrite 0x12345678";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Write(_, _)).Times(100);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, ReadTest)
 {
-	string user_input = "Read 1";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "Read 1" << endl;
+	user_input_out_file << "Exit" << endl;
 
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Read(_)).Times(1);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, FullReadTest)
 {
-	string user_input = "FullRead";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "FullRead" << endl;
+	user_input_out_file << "Exit" << endl;
 
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Read(_)).Times(100);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, EraseTest)
 {
-	string user_input = "Erase 0 1";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "Erase 0 1" << endl;
+	user_input_out_file << "Exit" << endl;
 
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Erase(_, _)).Times(1);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, EraseRangeTest)
 {
-	string user_input = "EraseRange 0 9";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "EraseRange 0 9" << endl;
+	user_input_out_file << "Exit" << endl;
 
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Erase(_, _)).Times(10);
+
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, FlushTest)
 {
-	string user_input = "Flush";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	ISSDApp* Issd_app = test_shell.get_ssd_app();
-
-	EXPECT_EQ(Issd_app, &app);
 	EXPECT_CALL(app, Flush()).Times(1);
+
 	test_shell.Run();
 }
+
 TEST_F(TestShellTestFixture, HelpTest)
 {
-	string help_input = "Help";
-	string exit_input = "Exit";
-	cout << help_input << endl;
-	cout << exit_input << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "Help" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
@@ -294,29 +183,26 @@ TEST_F(TestShellTestFixture, HelpTest)
 
 	test_shell.Run();
 
-	ifstream result_input_file(test_result_path);
 	string result;
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Help  ---  Run...Available commands:");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Write <addr> <data>: Write data to address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Read <addr>: Read data from address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "FullWrite <data>: Write data to full address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "FullRead : Read data from full address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Help: Show available commands");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Exit: Exit the program");
 }
 
 TEST_F(TestShellTestFixture, ExitTest)
 {
-	string user_input;
-	string write_input = "Exit";
-	cout << write_input << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
@@ -327,9 +213,9 @@ TEST_F(TestShellTestFixture, ExitTest)
 
 TEST_F(TestShellTestFixture, InputNormalWrite)
 {
-	cout << "Write 0 0x11112222" << endl;
-	cout << "Write 99 0x111AB222" << endl;
-	cout << "Exit" << endl;
+	user_input_out_file << "Write 0 0x11112222" << endl;
+	user_input_out_file << "Write 99 0x111AB222" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
@@ -346,9 +232,9 @@ TEST_F(TestShellTestFixture, InputNormalWrite)
 
 TEST_F(TestShellTestFixture, InputNormalRead)
 {
-	cout << "Read 4" << endl;
-	cout << "Read 49" << endl;
-	cout << "Exit" << endl;
+	user_input_out_file << "Read 4" << endl;
+	user_input_out_file << "Read 49" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
@@ -363,142 +249,118 @@ TEST_F(TestShellTestFixture, InputNormalRead)
 
 TEST_F(TestShellTestFixture, InputInvalidWrite)
 {
-	cout << "Write -1 0x11112222" << endl;
-	cout << "Write 100 0x111AB222" << endl;
-	cout << "Write 10 0x111TB222" << endl;
-	cout << "Write a 0x1111B222" << endl;
-	cout << "Write $s 0x111!B222" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "Write -1 0x11112222" << endl;
+	user_input_out_file << "Write 100 0x111AB222" << endl;
+	user_input_out_file << "Write 10 0x111TB222" << endl;
+	user_input_out_file << "Write a 0x1111B222" << endl;
+	user_input_out_file << "Write $s 0x111!B222" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
+	test_shell.Run();
+
 	string expected_invalid_addr = "[Error] Invalid Address";
 	string expected_invalid_data = "[Error] Invalid Data";
 	string result;
-	test_shell.Run();
-
-	ifstream result_input_file(test_result_path);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_data);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
 }
 
 TEST_F(TestShellTestFixture, InputInvalidRead)
 {
-	cout << "Read -1" << endl;
-	cout << "Read 100" << endl;
-	cout << "Read aaa" << endl;
-	cout << "Read $das " << endl;
-	cout << "Read $s " << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "Read -1" << endl;
+	user_input_out_file << "Read 100" << endl;
+	user_input_out_file << "Read aaa" << endl;
+	user_input_out_file << "Read $das " << endl;
+	user_input_out_file << "Read $s " << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	string expected_invalid_addr = "[Error] Invalid Address";
-	string result;
 	test_shell.Run();
 
-	ifstream result_input_file(test_result_path);
-	std::getline(result_input_file, result);
+	string expected_invalid_addr = "[Error] Invalid Address";
+	string result;
+
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_addr);
 }
 
 TEST_F(TestShellTestFixture, InputInvalidCMD)
 {
-	cout << "Writa -1 0x11112222" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "Writa -1 0x11112222" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
+
+	test_shell.Run();
 
 	string expected_invalid_cmd = "[Error] Invalid CMD";
 	string result;
-	test_shell.Run();
-
-	ifstream result_input_file(test_result_path);
-
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected_invalid_cmd);
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Available commands:");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Write <addr> <data>: Write data to address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Read <addr>: Read data from address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "FullWrite <data>: Write data to full address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "FullRead : Read data from full address");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Help: Show available commands");
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, "Exit: Exit the program");
 }
+
 TEST_F(TestShellTestFixture, TestApp1TestWithMock)
 {
-	string user_input = "testapp1";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "testapp1" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
+
 	uint32_t pattern1 = 0xABCDFFFF;
+	for (int addr = 0; addr < 100; ++addr)
+		EXPECT_CALL(app, Write(addr, pattern1));
 
 	for (int addr = 0; addr < 100; ++addr)
-	{
-		EXPECT_CALL(app, Write(addr, pattern1));
-	}
-	for (int addr = 0; addr < 100; ++addr)
-	{
 		EXPECT_CALL(app, Read(addr));
-	}
 
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, TestApp2TestWithMock)
 {
-	string user_input = "testapp2";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
+	user_input_out_file << "testapp2" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	MockSSDApp app;
 	TestShell test_shell;
@@ -508,32 +370,19 @@ TEST_F(TestShellTestFixture, TestApp2TestWithMock)
 	uint32_t pattern2 = 0x12345678;
 
 	for (uint32_t addr = 0; addr < 6; ++addr)
-	{
 		EXPECT_CALL(app, Write(addr, pattern1)).Times(50);
-	}
 	for (uint32_t addr = 0; addr < 6; ++addr)
-	{
 		EXPECT_CALL(app, Write(addr, pattern2));
-	}
 	for (uint32_t addr = 0; addr < 6; ++addr)
-	{
 		EXPECT_CALL(app, Read(addr));
-	}
 
 	test_shell.Run();
 }
 
 TEST_F(TestShellTestFixture, TestApp1TestWithSSD)
 {
-	string user_input = "testapp1";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "testapp1" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
@@ -541,25 +390,17 @@ TEST_F(TestShellTestFixture, TestApp1TestWithSSD)
 
 	test_shell.Run();
 
-	ifstream result_input_file(test_result_path);
 	string result;
 	string expected = "testapp1  ---  Run...Pass";
 
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected);
 }
 
 TEST_F(TestShellTestFixture, TestApp2TestWithSSD)
 {
-	string user_input = "testapp2";
-	string exit_input = "Exit";
-	cout << user_input << endl;
-	cout << exit_input << endl;
-
-	string test_result_path = "./test_result.txt";
-	ofstream result_out_file;
-	result_out_file.open(test_result_path, ofstream::trunc | ofstream::out);
-	cout.rdbuf(result_out_file.rdbuf());
+	user_input_out_file << "testapp2" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
@@ -567,160 +408,153 @@ TEST_F(TestShellTestFixture, TestApp2TestWithSSD)
 
 	test_shell.Run();
 
-	ifstream result_input_file(test_result_path);
 	string result;
 	string expected = "testapp2  ---  Run...Pass";
 
-	std::getline(result_input_file, result);
+	getline(result_input_file, result);
 	EXPECT_EQ(result, expected);
 }
 
 TEST_F(TestShellTestFixture, SSDWriteTest)
 {
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0x11112222;
-	int expected_addr = 1;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0x11112222;
+	uint32_t expected_addr = 1;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	in.seekg(expected_addr * sizeof(uint32_t));
 	in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDReadTest)
 {
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Read 1" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "Result.txt";
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Read 1" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	string expected_data = "0x11112222";
-	int expected_addr = 0;
-	string result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	string expected_data = "0x11112222";
+	uint32_t expected_addr = 0;
+	string result;
 
+	ifstream in("result.txt", std::ios::binary);
 	in.seekg(0);
-	std::getline(in, result);
+	getline(in, result);
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 TEST_F(TestShellTestFixture, SSDEraseTest)
 {
-	cout << "Write 0 0x11112222" << endl;
-	cout << "Erase 0 1" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "Write 0 0x11112222" << endl;
+	user_input_out_file << "Erase 0 1" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0;
-	int expected_addr = 0;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0;
+	uint32_t expected_addr = 0;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	in.seekg(expected_addr * sizeof(uint32_t));
 	in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDFullWriteTest)
 {
-	cout << "FullWrite 0x12345678" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0x12345678;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0x12345678;
+	uint32_t result;
 
-	for (int expected_addr = 0; expected_addr < 100; expected_addr++)
+	ifstream in("nand.txt", std::ios::binary);
+	for (uint32_t expected_addr = 0; expected_addr < 100; expected_addr++)
 	{
 		in.seekg(expected_addr * sizeof(uint32_t));
 		in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
 
 		EXPECT_EQ(result, expected_data);
 	}
+	in.close();
 }
 
 TEST_F(TestShellTestFixture, SSDFullReadTest)
 {
-	cout << "FullRead" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "Result.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "FullRead" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
+	test_shell.Run();
+
+	ifstream in("result.txt", std::ios::in);
 	string expected_data = "0x12345678";
 	string result;
-
-	test_shell.Run();
-	std::ifstream in(test_result_path, std::ios::in);
-	in.seekg(0);
 	in >> result;
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDEraseRangeTest)
 {
-	cout << "FullWrite 0x12345678" << endl;
-	cout << "EraseRange 0 9" << endl;
-	cout << "Flush" << endl;
-	cout << "Exit" << endl;
-	const uint32_t startaddress = 0;
-	const uint32_t endaddress = 9;
-	string test_result_path = "nand.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "EraseRange 0 9" << endl;
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	const uint32_t startaddress = 0;
+	const uint32_t endaddress = 9;
+	uint32_t expected_data = 0;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	for (int addrindex = startaddress; addrindex < endaddress; addrindex++)
 	{
 		in.seekg(addrindex * sizeof(uint32_t));
@@ -728,178 +562,172 @@ TEST_F(TestShellTestFixture, SSDEraseRangeTest)
 
 		EXPECT_EQ(result, expected_data);
 	}
+	in.close();
 }
 
 TEST_F(TestShellTestFixture, SSDWriteTestWithoutFlush)
 {
-	cout << "Erase 1 1" << endl; // PreCondition ExpectData : 0
-	cout << "Flush" << endl;
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "Erase 1 1" << endl; // PreCondition ExpectData : 0
+	user_input_out_file << "Flush" << endl;
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0;
-	int expected_addr = 1;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0;
+	uint32_t expected_addr = 1;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	in.seekg(expected_addr * sizeof(uint32_t));
 	in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDReadTestWithoutFlush)
 {
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Read 1" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "Result.txt";
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Read 1" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	string expected_data = "0x11112222";
-	int expected_addr = 0;
-	string result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	string expected_data = "0x11112222";
+	uint32_t expected_addr = 0;
+	string result;
 
+	ifstream in("result.txt", std::ios::binary);
 	in.seekg(0);
-	std::getline(in, result);
+	getline(in, result);
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 TEST_F(TestShellTestFixture, SSDEraseTestWithoutFlush)
 {
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Flush" << endl; // PreCondition Write
-	cout << "Erase 1 1" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Flush" << endl; // PreCondition Write
+	user_input_out_file << "Erase 1 1" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0x11112222;
-	int expected_addr = 1;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0x11112222;
+	uint32_t expected_addr = 1;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	in.seekg(expected_addr * sizeof(uint32_t));
 	in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDReadTestAfterEraseWithoutFlush)
 {
-	const string EmptyData = "0x00000000";
-	cout << "Write 1 0x11112222" << endl;
-	cout << "Flush" << endl; // PreCondition Write
-	cout << "Erase 1 1" << endl;
-	cout << "Read 1" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "result.txt";
+	user_input_out_file << "Write 1 0x11112222" << endl;
+	user_input_out_file << "Flush" << endl; // PreCondition Write
+	user_input_out_file << "Erase 1 1" << endl;
+	user_input_out_file << "Read 1" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	string expected_data = EmptyData; // 빈칸 데이터 0
-	int expected_addr = 1;
-	string result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::in);
+	const string expected_data = "0x00000000"; // 빈칸 데이터 0
+	uint32_t expected_addr = 1;
+	string result;
+
+	ifstream in("result.txt", std::ios::in);
 	in >> result;
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDFullWriteTestWithoutFlush)
 {
-	cout << "FullWrite 0x12345678" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "nand.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0x12345678;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	uint32_t expected_data = 0x12345678;
+	uint32_t result;
 
-	for (int expected_addr = 0; expected_addr < 100; expected_addr++)
+	ifstream in("nand.txt", std::ios::binary);
+	for (uint32_t expected_addr = 0; expected_addr < 100; expected_addr++)
 	{
 		in.seekg(expected_addr * sizeof(uint32_t));
 		in.read(reinterpret_cast<char*>(&result), sizeof(uint32_t));
 
 		EXPECT_EQ(result, expected_data);
 	}
+	in.close();
 }
 
 TEST_F(TestShellTestFixture, SSDFullReadTestWithoutFlush)
 {
-	cout << "FullWrite 0x12345678" << endl;
-	cout << "FullRead" << endl;
-	cout << "Exit" << endl;
-
-	string test_result_path = "Result.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "FullRead" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
+	test_shell.Run();
+
 	string expected_data = "0x12345678";
 	string result;
 
-	test_shell.Run();
-	std::ifstream in(test_result_path, std::ios::in);
-	in.seekg(0);
+	ifstream in("result.txt", std::ios::in);
 	in >> result;
+	in.close();
 
 	EXPECT_EQ(result, expected_data);
 }
 
 TEST_F(TestShellTestFixture, SSDEraseRangeTestWithoutFlush)
 {
-	cout << "FullWrite 0x12345678" << endl;
-	cout << "EraseRange 0 9" << endl;
-	cout << "Exit" << endl;
-	const uint32_t startaddress = 0;
-	const uint32_t endaddress = 9;
-	string test_result_path = "nand.txt";
+	user_input_out_file << "FullWrite 0x12345678" << endl;
+	user_input_out_file << "EraseRange 0 9" << endl;
+	user_input_out_file << "Exit" << endl;
 
 	SSD_Adaptor app;
 	TestShell test_shell;
 	test_shell.set_ssd_app(&app);
 
-	uint32_t expected_data = 0;
-	uint32_t result;
 	test_shell.Run();
 
-	std::ifstream in(test_result_path, std::ios::binary);
+	const uint32_t startaddress = 0;
+	const uint32_t endaddress = 9;
+	uint32_t expected_data = 0;
+	uint32_t result;
 
+	ifstream in("nand.txt", std::ios::binary);
 	for (int addrindex = startaddress; addrindex < endaddress; addrindex++)
 	{
 		in.seekg(addrindex * sizeof(uint32_t));
@@ -907,4 +735,38 @@ TEST_F(TestShellTestFixture, SSDEraseRangeTestWithoutFlush)
 
 		EXPECT_EQ(result, expected_data);
 	}
+	in.close();
+}
+
+TEST_F(TestShellTestFixture, RunnerTest)
+{
+	string sample_script_path = "SampleScript.lst";
+	string write_cmd = "Write 1 0x1234AAAA";
+	string read_cmd = "Read 1";
+	string full_write_cmd = "FullWrite 0x43215678";
+	string full_read_cmd = "FullRead";
+	string exit_cmd = "Exit";
+
+	ofstream script_fout(sample_script_path, ios_base::out | ios_base::trunc);
+	script_fout << write_cmd << endl;
+	script_fout << read_cmd << endl;
+	script_fout << full_write_cmd << endl;
+	script_fout << full_read_cmd << endl;
+	script_fout << exit_cmd << endl;
+	script_fout.close();
+
+	SSD_Adaptor app;
+	TestShell test_shell;
+	test_shell.set_ssd_app(&app);
+	test_shell.ScriptRun(sample_script_path.c_str());
+
+	string result;
+	getline(result_input_file, result);
+	EXPECT_EQ(result, write_cmd + "  ---  Run...Pass");
+	getline(result_input_file, result);
+	EXPECT_EQ(result, read_cmd + "  ---  Run...Pass");
+	getline(result_input_file, result);
+	EXPECT_EQ(result, full_write_cmd + "  ---  Run...Pass");
+	getline(result_input_file, result);
+	EXPECT_EQ(result, full_read_cmd + "  ---  Run...Pass");
 }


### PR DESCRIPTION
TestShell의 unittest에서 혼재된 파일 입출력을 정리했습니다.
이를 통해 TestFixture에서 공통으로 필요한 각 filestream을 멤버변수로 가지게 됩니다.
그리고 unit test 가독성을 높이는 차원에서 라인 정리 등이 진행됐습니다.