### PR TITLE
[Refactoring] Separate printing for runners as a function

### DIFF
--- a/ssd_app_test/SSD_Adaptor.cpp
+++ b/ssd_app_test/SSD_Adaptor.cpp
@@ -17,7 +17,7 @@ SSD_Adaptor::Read(const uint32_t  addr)
 string 
 SSD_Adaptor::GetReadCMD(const uint32_t addr)
 {
-    const string kReadCMD = "..\\x64\\Debug\\ssd_app.exe R";
+    const string kReadCMD = ssd_app_path + " R";
     return kReadCMD + " " + to_string(addr);
 }
 
@@ -42,7 +42,7 @@ SSD_Adaptor::Write(const uint32_t addr, const uint32_t data) {
 string
 SSD_Adaptor::GetWriteCMD(const uint32_t addr, const uint32_t data)
 {
-    const string kWriteCMD = "..\\x64\\Debug\\ssd_app.exe W ";
+    const string kWriteCMD = ssd_app_path + " W ";
     ostringstream data_ss;
     data_ss << "0x" << setfill('0') << hex << setw(8) << uppercase << data;
     auto ret = kWriteCMD + " " + to_string(addr) + " " + data_ss.str();
@@ -57,12 +57,12 @@ SSD_Adaptor::Erase(const uint32_t addr, const uint32_t size) {
 string
 SSD_Adaptor::GetEraseCMD(const uint32_t addr, const uint32_t size)
 {
-    const string kWriteCMD = "..\\x64\\Debug\\ssd_app.exe E ";
+    const string kWriteCMD = ssd_app_path + " E ";
     return kWriteCMD + " " + to_string(addr) + " " + to_string(size);
 }
 
 void
 SSD_Adaptor::Flush(void)
 {
-    system("..\\x64\\Debug\\ssd_app.exe F");
+    system((ssd_app_path + " F").c_str());
 }

--- a/ssd_app_test/SSD_Adaptor.h
+++ b/ssd_app_test/SSD_Adaptor.h
@@ -7,6 +7,7 @@ public:
     void Erase(const uint32_t addr, const uint32_t size) override;
     void Flush(void) override;
 private:
+    std::string ssd_app_path = "..\\x64\\Debug\\ssd_app.exe";
     std::string GetReadCMD(const uint32_t addr);
     std::string GetWriteCMD(const uint32_t addr, const uint32_t data);
     std::string GetEraseCMD(const uint32_t addr, const uint32_t size);

--- a/ssd_app_test/TestShell.cpp
+++ b/ssd_app_test/TestShell.cpp
@@ -11,32 +11,39 @@
 
 using namespace std;
 #define LOGGER Logger::GetLogger()
+
+void
+TestShell::PrintRunnerCMDStart(void)
+{
+    if (ShellCMD != EXIT)
+        LOGGER.PrintOutALineWithoutEndl(ONLY_RUNNER, user_input + "  ---  Run...", __func__);
+}
+
+void 
+TestShell::PrintRunnerCMDEnd(bool isPassed)
+{
+    if (ShellCMD != EXIT)
+    {
+        if (isPassed)
+            LOGGER.PrintOutALine(ONLY_RUNNER, "Pass", __func__);
+        else
+        {
+            LOGGER.PrintOutALine(ONLY_RUNNER, "FAIL!", __func__);
+            return;
+        }
+    }
+}
+
 void 
 TestShell::Run(void)
 {
-    bool isCMDPass;
-    TestShellCMD ShellCMD = HELP;
     while (ShellCMD != EXIT)
     {
-        isCMDPass = true;
         if (!CreateCommand()) continue;
 
-        ShellCMD = icmd->GetCMD();
-        
-        if (ShellCMD != EXIT)
-            LOGGER.PrintOutALineWithoutEndl(ONLY_RUNNER, user_input + "  ---  Run...", __func__);
-        isCMDPass = icmd->Run();
-
-        if (ShellCMD != EXIT)
-        {
-            if (isCMDPass)
-                LOGGER.PrintOutALine(ONLY_RUNNER, "Pass", __func__);
-            else
-            {
-                LOGGER.PrintOutALine(ONLY_RUNNER, "FAIL!", __func__);
-                return;
-            }
-        }
+        PrintRunnerCMDStart();
+        bool isPassed = icmd->Run();
+        PrintRunnerCMDEnd(isPassed);
     }
 }
 
@@ -76,6 +83,7 @@ TestShell::CreateCommand(void) {
     {
         return false;
     }
+    ShellCMD = icmd->GetCMD();
 }
 
 void 

--- a/ssd_app_test/TestShell.h
+++ b/ssd_app_test/TestShell.h
@@ -13,7 +13,10 @@ public:
     void ScriptRun(const char* script_path);
     void set_ssd_app(ISSDApp* app);
 private:
+    void PrintRunnerCMDStart();
+    void PrintRunnerCMDEnd(bool isPassed);
     bool CreateCommand(void);
+    TestShellCMD ShellCMD = HELP;
     ISSDApp* ssd_app;
     ICommand* icmd;
     std::string user_input;

--- a/ssd_app_test_gtest/main.cpp
+++ b/ssd_app_test_gtest/main.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    RUN_ALL_TESTS();
+
+    while (1);
+    return 0;
+}

--- a/ssd_app_test_gtest/ssd_app_test_gtest.vcxproj
+++ b/ssd_app_test_gtest/ssd_app_test_gtest.vcxproj
@@ -107,6 +107,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ssd_app_test\ssd_app_test.vcxproj">


### PR DESCRIPTION
Testshell의 Run 함수에서 runner용 출력 부분을 별도 함수로 분리하고,
shellcmd를 멤버변수로 옮겨 코드를 정리했습니다.